### PR TITLE
Fix license key generation when email is too short

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -173,8 +173,12 @@ func isValidLicense(licenseKey string) bool {
 // generateLicenseKey generates a license key from an email
 func generateLicenseKey(email string) string {
 	// In a real implementation, this would generate a cryptographically secure key
-	// For demo, we'll just use a simple hash
-	return fmt.Sprintf("LICENSE-%s-%d", email[:4], time.Now().Unix())
+	// For demo, we'll just use a simple hash. Handle short emails gracefully.
+	prefix := email
+	if len(prefix) > 4 {
+		prefix = prefix[:4]
+	}
+	return fmt.Sprintf("LICENSE-%s-%d", prefix, time.Now().Unix())
 }
 
 // generateSignature creates a signature for a license

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func TestGenerateLicenseKey_ShortEmail(t *testing.T) {
+	key := generateLicenseKey("a@b")
+	if key == "" {
+		t.Fatal("expected non-empty license key")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid slicing beyond bounds in `generateLicenseKey`
- add regression test for short email addresses

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*